### PR TITLE
implemented new duedate references

### DIFF
--- a/TaskCore.App/Options/AddTaskOptions.cs
+++ b/TaskCore.App/Options/AddTaskOptions.cs
@@ -9,7 +9,7 @@ namespace TaskCore.App.Options
         [OptionName("name", Alias = "n", Description = "Name of the task.")]
         public string Title { get; set; }
 
-        [OptionName("duedate", Alias = "d", Description = "Numeric value or today, tomorrow, nextweek, nextmonth")]
+        [OptionName("duedate", Alias = "d", Description = "Date(01/01/2010), Numeric value(Adds value from today and selects it), Strings: today, tomorrow, nextweek or \"next week\", nextmonth or \"next month\"")]
         public string DueDate { get; set; }
 
         [OptionName("priority", Alias = "p")]

--- a/TaskCore.App/Options/AddTaskOptions.cs
+++ b/TaskCore.App/Options/AddTaskOptions.cs
@@ -9,7 +9,7 @@ namespace TaskCore.App.Options
         [OptionName("name", Alias = "n", Description = "Name of the task.")]
         public string Title { get; set; }
 
-        [OptionName("duedate", Alias = "d")]
+        [OptionName("duedate", Alias = "d", Description = "Numeric value or today, tomorrow, nextweek, nextmonth")]
         public string DueDate { get; set; }
 
         [OptionName("priority", Alias = "p")]

--- a/TaskCore.App/Options/AddTaskOptions.cs
+++ b/TaskCore.App/Options/AddTaskOptions.cs
@@ -9,7 +9,7 @@ namespace TaskCore.App.Options
         [OptionName("name", Alias = "n", Description = "Name of the task.")]
         public string Title { get; set; }
 
-        [OptionName("duedate", Alias = "d", Description = "Date(01/01/2010), Numeric value(Adds value from today and selects it), Strings: today, tomorrow, nextweek or \"next week\", nextmonth or \"next month\"")]
+        [OptionName("duedate", Alias = "d", Description = "01/01/2010, 15(Adds 15 days from today and selects it), today, tomorrow, nextweek or \"next week\", nextmonth or \"next month\"")]
         public string DueDate { get; set; }
 
         [OptionName("priority", Alias = "p")]

--- a/TaskCore.App/Verbs/AddTask.cs
+++ b/TaskCore.App/Verbs/AddTask.cs
@@ -27,7 +27,7 @@ namespace TaskCore.App.Verbs
             {
                 return new AddTaskRequiredFieldsMissingView();
             }
-            
+
             Category category = new Category();
             // Inbox is the default category, which cannot be deleted, added, or edited.
             if (string.IsNullOrWhiteSpace(Options.Category))
@@ -43,13 +43,48 @@ namespace TaskCore.App.Verbs
                 category.Name = Options.Category;
             }
 
+            if (!string.IsNullOrWhiteSpace(Options.DueDate))
+            {
+                string loweredDueDate = Options.DueDate.ToLower();
+
+                var isDueDateNumeric = double.TryParse(loweredDueDate, out _);
+
+                if (isDueDateNumeric)
+                {
+                    Options.DueDate = DateTime.Now.AddDays(double.Parse(loweredDueDate)).ToShortDateString();
+                }
+                else
+                {
+                    if (loweredDueDate == "today")
+                    {
+                        Options.DueDate = DateTime.Now.ToShortDateString();
+                    }
+                    else if (loweredDueDate == "tomorrow")
+                    {
+                        Options.DueDate = DateTime.Now.AddDays(1).ToShortDateString();
+                    }
+                    else if (loweredDueDate == "nextweek")
+                    {
+                        Options.DueDate = DateTime.Now.AddDays(7).ToShortDateString();
+                    }
+                    else if (loweredDueDate == "nextmonth")
+                    {
+                        Options.DueDate = DateTime.Now.AddDays(30).ToShortDateString();
+                    }
+                    else
+                    {
+                        Options.DueDate = null;
+                    }
+                }
+            }
+
             // TODO Perform some input validation here, for required fields, etc.
             _todoTaskRepository.Add(new TodoTask()
             {
                 Title = Options.Title,
                 DueDateTime = Options.DueDate != null
                     ? DateTimeOffset.Parse(Options.DueDate, CultureInfo.CurrentCulture)
-                    : (DateTimeOffset?) null,
+                    : (DateTimeOffset?)null,
                 // CategoryId is a getter only hash value so we don't need to make a DB call to get it by the category name.
                 CategoryId = category.CategoryId,
                 Priority = Options.Priority,

--- a/TaskCore.App/Verbs/AddTask.cs
+++ b/TaskCore.App/Verbs/AddTask.cs
@@ -72,8 +72,14 @@ namespace TaskCore.App.Verbs
                             Options.DueDate = DateTime.Now.AddDays(30).ToShortDateString();
                             break;
                         default:
-                            Options.DueDate = null;
-                            break;
+                            {
+                                var isDueDateDateTime = DateTime.TryParse(loweredDueDate, out _);
+                                if (!isDueDateDateTime)
+                                {
+                                    Options.DueDate = null;
+                                }
+                                break;
+                            }
                     }
                 }
             }

--- a/TaskCore.App/Verbs/AddTask.cs
+++ b/TaskCore.App/Verbs/AddTask.cs
@@ -47,33 +47,33 @@ namespace TaskCore.App.Verbs
             {
                 string loweredDueDate = Options.DueDate.ToLower();
 
-                var isDueDateNumeric = double.TryParse(loweredDueDate, out _);
+                var isDueDateNumeric = int.TryParse(loweredDueDate, out _);
 
                 if (isDueDateNumeric)
                 {
-                    Options.DueDate = DateTime.Now.AddDays(double.Parse(loweredDueDate)).ToShortDateString();
+                    Options.DueDate = DateTime.Now.AddDays(int.Parse(loweredDueDate)).ToShortDateString();
                 }
                 else
                 {
-                    if (loweredDueDate == "today")
+                    switch (loweredDueDate)
                     {
-                        Options.DueDate = DateTime.Now.ToShortDateString();
-                    }
-                    else if (loweredDueDate == "tomorrow")
-                    {
-                        Options.DueDate = DateTime.Now.AddDays(1).ToShortDateString();
-                    }
-                    else if (loweredDueDate == "nextweek")
-                    {
-                        Options.DueDate = DateTime.Now.AddDays(7).ToShortDateString();
-                    }
-                    else if (loweredDueDate == "nextmonth")
-                    {
-                        Options.DueDate = DateTime.Now.AddDays(30).ToShortDateString();
-                    }
-                    else
-                    {
-                        Options.DueDate = null;
+                        case "today":
+                            Options.DueDate = DateTime.Now.ToShortDateString();
+                            break;
+                        case "tomorrow":
+                            Options.DueDate = DateTime.Now.AddDays(1).ToShortDateString();
+                            break;
+                        case "nextweek":
+                        case "next week":
+                            Options.DueDate = DateTime.Now.AddDays(7).ToShortDateString();
+                            break;
+                        case "nextmonth":
+                        case "next month":
+                            Options.DueDate = DateTime.Now.AddDays(30).ToShortDateString();
+                            break;
+                        default:
+                            Options.DueDate = null;
+                            break;
                     }
                 }
             }

--- a/TaskCore.App/Views/ListTasksView.cs
+++ b/TaskCore.App/Views/ListTasksView.cs
@@ -106,7 +106,8 @@ namespace TaskCore.App.Views
                 Write($"in {_categoriesDict[task.CategoryId]}");
                 if (_options.Verbose)
                 {
-                    Write($" - {task.CreationDate:F}.");
+                    Write($" - Created on {task.CreationDate:F}.");
+                    Write($" - Due Date on {task.DueDateTime:F}");
                 }
 
                 WriteLine();


### PR DESCRIPTION
.\taskcore add -t "sample" -d 01/01/2010: selects date value
.\taskcore add -t "sample" -d 15: adds 15 days from today and selects it
.\taskcore add -t "sample" -d today, selects today
.\taskcore add -t "sample" -d tomorrow: adds 1 day from today and selects it
.\taskcore add -t "sample" -d nextweek or "next week": adds 7 days from today and selects it
.\taskcore add -t "sample" -d nextmonth or "next month": adds 30 days from today and selects it

.\taskcore add -t "sample" -d asd: don't use the duedate option